### PR TITLE
added BEGIN keyword to awk parse, parse was not recognizing the delim…

### DIFF
--- a/MyPage/traffic_monitor.sh
+++ b/MyPage/traffic_monitor.sh
@@ -7,7 +7,7 @@ fi
 
 # Bandwidth Download/Upload Rate Counter
 LAN_IFACE=$(nvram get lan_ifname)
-LAN_TYPE=$(nvram get lan_ipaddr | awk ' { FS="."; print $1"."$2 }')
+LAN_TYPE=$(nvram get lan_ipaddr | awk ' BEGIN { FS="." }; { print $1"."$2 }')
 
 if [ -f /tmp/traffic_monitor.lock ];
 then


### PR DESCRIPTION
…iter spec without it on DD-WRT build 25697.  I don't know if existing master branch worked on previous versions of DD-WRT.  I don't know specifically which versions of DD-WRT this update works, I just know that it works on build 25697 which I am using.
